### PR TITLE
Add comprehensive GitHub wiki with Mermaid diagrams

### DIFF
--- a/wiki_files/Architecture-Overview.md
+++ b/wiki_files/Architecture-Overview.md
@@ -1,0 +1,106 @@
+# Architecture Overview
+
+ChemPal is a Chrome Manifest v3 extension that searches multiple chemical supplier websites in parallel and presents results in a unified, filterable table.
+
+## High-Level Architecture
+
+```mermaid
+flowchart TB
+subgraph Extension["Chrome Extension (Manifest v3)"]
+direction TB
+
+subgraph EntryPoints["Entry Points"]
+direction LR
+POPUP["Popup / SidePanel\n(React 19)"]
+SW["Service Worker\n(background)"]
+STORAGE[("chrome.storage\n.local (cache)\n.session (state)")]
+end
+
+subgraph AppLayer["Application Layer"]
+direction TB
+SEARCH["SearchPanel"]
+SETTINGS["SettingsPanel"]
+STATS["StatsPanel"]
+DRAWER["DrawerSystem"]
+FAVS["FavoritesPanel"]
+HISTORY["HistoryPanel"]
+end
+
+subgraph SearchExec["Search Execution"]
+direction LR
+HOOK["useSearch hook"]
+FACTORY["SupplierFactory"]
+S1["Supplier 1"]
+S2["Supplier 2"]
+S3["Supplier ..."]
+SN["Supplier 17"]
+FACTORY --> S1 & S2 & S3 & SN
+end
+
+POPUP --> AppLayer
+SEARCH --> HOOK --> FACTORY
+AppLayer <-.-> STORAGE
+end
+
+subgraph External["External APIs & Supplier Sites"]
+direction LR
+WIX["Wix"]
+SHOPIFY["Shopify"]
+WOO["WooCommerce"]
+CUSTOM["Custom HTML"]
+PUBCHEM["PubChem"]
+HEXARATE["Hexarate\n(currency)"]
+end
+
+S1 & S2 & S3 & SN --> External
+
+classDef entry fill:#4A90D9,stroke:#2C5F8A,color:#fff
+classDef app fill:#5BA3CF,stroke:#3A7CA5,color:#fff
+classDef exec fill:#27AE60,stroke:#1E8449,color:#fff
+classDef storage fill:#E8A838,stroke:#B8841F,color:#fff
+classDef external fill:#9B59B6,stroke:#6F3D8A,color:#fff
+
+class POPUP,SW entry
+class SEARCH,SETTINGS,STATS,DRAWER,FAVS,HISTORY app
+class HOOK,FACTORY,S1,S2,S3,SN exec
+class STORAGE storage
+class WIX,SHOPIFY,WOO,CUSTOM,PUBCHEM,HEXARATE external
+```
+
+## Key Design Decisions
+
+### Streaming Results
+Rather than waiting for all suppliers to finish, `SupplierFactory` uses an `AsyncGenerator` to yield products as they arrive. The UI updates incrementally — users see results within seconds even though some suppliers may take longer.
+
+### Supplier Abstraction
+All suppliers extend `SupplierBase`, which defines the lifecycle: `setup()` → `queryProducts()` → `fuzzyFilter()` → `initProductBuilders()` → `getProductData()` → `yield product`. Platform-specific base classes (`SupplierBaseWix`, `SupplierBaseShopify`, `SupplierBaseWoocommerce`) handle common patterns for those e-commerce platforms.
+
+### Two-Level Caching
+- **Query cache** (`chrome.storage.local`) — caches search result lists per supplier, keyed by query + supplier name
+- **Product data cache** (`chrome.storage.local`) — caches individual product detail fetches, keyed by URL + supplier
+
+Both use LRU eviction at 100 entries. See [Caching](Caching) for details.
+
+### State Management
+The app uses React 19's `useActionState` for settings, with `AppContext` providing global state. The Chrome extension persists query state and results to `chrome.storage.session` for seamless restore-on-mount.
+
+## Chrome Extension Entry Points
+
+| Entry Point | File | Description |
+|-------------|------|-------------|
+| Popup / Side Panel | `index.html` → `App.tsx` | Main React application |
+| Service Worker | `service-worker.js` | Background processing (currently minimal) |
+| Manifest | `public/manifest.json` | Extension configuration (Manifest v3) |
+
+## Core Modules
+
+| Module | Path | Role |
+|--------|------|------|
+| `SupplierBase` | `src/suppliers/SupplierBase.ts` | Abstract base class for all supplier implementations |
+| `SupplierFactory` | `src/suppliers/SupplierFactory.ts` | Orchestrates parallel supplier queries via async generator |
+| `ProductBuilder` | `src/utils/ProductBuilder.ts` | Builds and validates product objects with a fluent API |
+| `SupplierCache` | `src/utils/SupplierCache.ts` | Chrome storage caching layer with LRU eviction |
+| `Logger` | `src/utils/Logger.ts` | Structured logging with per-supplier prefixes |
+| `Pubchem` | `src/utils/Pubchem.ts` | PubChem compound lookups and suggestions |
+| `SupplierStatsStore` | `src/utils/SupplierStatsStore.ts` | Tracks per-supplier success/failure/timing stats |
+| `fetchDecorator` | `src/utils/fetchDecorator.ts` | Enhanced fetch wrapper with response capture support |

--- a/wiki_files/Caching.md
+++ b/wiki_files/Caching.md
@@ -1,0 +1,143 @@
+# Caching
+
+ChemPal caches search results and product data in `chrome.storage.local` to avoid redundant network requests across searches.
+
+## Key Concepts
+
+- **Two independent caches**: Query results and product details are cached separately with different key generation strategies
+- **LRU eviction**: Both caches cap at 100 entries, evicting the least recently used when full
+- **Limit-aware invalidation**: The query cache invalidates entries when a new search requests more results than the cached limit
+- **Timestamp refresh on read**: Product data cache updates `cachedAt` on hit to prevent active entries from being evicted
+- **Serialization**: `ProductBuilder.dump()` serializes builders for storage; `ProductBuilder.createFromCache()` re-hydrates them
+
+## Cache Architecture
+
+```mermaid
+flowchart TB
+
+subgraph Init["Cache Initialization"]
+direction TB
+SB["SupplierBase constructor"]
+IC["initCache()\nthis.cache = new SupplierCache(supplierName)"]
+SC["SupplierCache instance\nscoped to supplier name\ne.g. Loudwolf, Onyxmet"]
+SB --> IC --> SC
+end
+
+subgraph Storage["Chrome Storage Backend"]
+direction LR
+QCS[("chrome.storage.local\nQuery Results Cache\nkey: SupplierCache.getQueryCacheKey()")]
+PDS[("chrome.storage.local\nProduct Data Cache\nkey: SupplierCache.getProductDataCacheKey()")]
+end
+
+subgraph QueryCache["Query Results Cache Flow"]
+direction TB
+QPC["queryProductsWithCache(query, limit)"]
+subgraph KeyGen1["Key Generation"]
+GCK["generateCacheKey(query, supplierName)\nbase64(query + supplierName)\nfallback: Buffer then MD5 hash"]
+end
+QPC --> GCK
+QLOOKUP{"Cache lookup\ncache key exists?"}
+GCK --> QLOOKUP
+subgraph CacheHit1["Cache Hit"]
+direction TB
+LIMITCHK{"cached.limit\nless than requested limit?"}
+INVALIDATE["Invalidate entry\ndelete cache key\nsave back to storage"]
+RESTORE["ProductBuilder.createFromCache(baseURL, data)\nre-hydrate builders from\ncached serialized data\nslice to requested limit"]
+LIMITCHK -->|"yes - insufficient data"| INVALIDATE
+LIMITCHK -->|"no - sufficient"| RESTORE
+end
+subgraph CacheMiss1["Cache Miss"]
+direction TB
+QP["queryProducts(query, limit)\nsupplier-specific fetch"]
+DUMP1["results.map b.dump\nserialize ProductBuilders"]
+SAVE1["cache.cacheQueryResults(\nquery, supplierName, results, limit)"]
+QP --> DUMP1 --> SAVE1
+end
+QLOOKUP -->|"hit"| CacheHit1
+QLOOKUP -->|"miss"| CacheMiss1
+INVALIDATE -->|"re-fetch"| CacheMiss1
+end
+
+SAVE1 -->|"write"| QCS
+QLOOKUP -.->|"read"| QCS
+INVALIDATE -.->|"delete + write"| QCS
+
+subgraph ProductCache["Product Data Cache Flow"]
+direction TB
+GPD["getProductData(product)\ncalled per product in execute() loop"]
+subgraph KeyGen2["Key Generation"]
+GPCK["getProductDataCacheKey(url, supplierName, params?)\nMD5 hash of url + supplierName + params"]
+end
+GPD --> GPCK
+PLOOKUP{"getCachedProductData(key)\nexists?"}
+GPCK --> PLOOKUP
+subgraph CacheHit2["Cache Hit"]
+direction TB
+TOUCH["updateProductDataCacheTimestamp(key)\nrefresh cachedAt to prevent\nLRU eviction"]
+SETDATA["product.setData(cachedData)\nhydrate builder with\ncached product details"]
+TOUCH --> SETDATA
+end
+subgraph CacheMiss2["Cache Miss"]
+direction TB
+FETCH["getProductDataWithCache(product, fetcher, params)\ncall supplier-specific fetcher"]
+DUMP2["resultBuilder.dump()\nserialize product data"]
+SAVE2["cache.cacheProductData(key, data)"]
+FETCH --> DUMP2 --> SAVE2
+end
+PLOOKUP -->|"hit"| CacheHit2
+PLOOKUP -->|"miss"| CacheMiss2
+end
+
+SAVE2 -->|"write"| PDS
+PLOOKUP -.->|"read"| PDS
+TOUCH -.->|"update timestamp"| PDS
+
+subgraph LRU["LRU Eviction Policy"]
+direction TB
+MAX["Max entries: 100 per cache\nquery cache and product cache\neach have independent limits"]
+EVICT["On write: if entries ≥ 100\nsort by cachedAt ascending\ndelete oldest entry"]
+MAX --- EVICT
+end
+
+SAVE1 -.->|"triggers if full"| LRU
+SAVE2 -.->|"triggers if full"| LRU
+
+subgraph Metadata["CacheMetadata - per entry"]
+direction LR
+META["cachedAt: timestamp\nversion: 1\nquery: search term\nsupplier: supplier name\nresultCount: number of results\nlimit: requested limit"]
+end
+
+SAVE1 -.->|"attached as __cacheMetadata"| Metadata
+SAVE2 -.->|"attached as __cacheMetadata"| Metadata
+
+classDef init fill:#4A90D9,stroke:#2C5F8A,color:#fff,font-weight:bold
+classDef storage fill:#E8A838,stroke:#B8841F,color:#fff,font-weight:bold
+classDef cacheFlow fill:#5A7D8B,stroke:#3E5A66,color:#fff
+classDef hit fill:#27AE60,stroke:#1E8449,color:#fff
+classDef miss fill:#D97B2A,stroke:#A35D1F,color:#fff
+classDef decision fill:#F5D76E,stroke:#C5A83D,color:#333,font-weight:bold
+classDef lru fill:#E74C3C,stroke:#C0392B,color:#fff
+classDef meta fill:#8E44AD,stroke:#6C3483,color:#fff
+classDef keygen fill:#1ABC9C,stroke:#148F77,color:#fff
+
+class SB,IC,SC init
+class QCS,PDS storage
+class QPC,GPD cacheFlow
+class RESTORE,SETDATA,TOUCH hit
+class QP,DUMP1,SAVE1,FETCH,DUMP2,SAVE2 miss
+class QLOOKUP,PLOOKUP,LIMITCHK decision
+class MAX,EVICT,INVALIDATE lru
+class META meta
+class GCK,GPCK keygen
+```
+
+## Query Cache vs Product Data Cache
+
+| | Query Results Cache | Product Data Cache |
+|---|---|---|
+| **Purpose** | Cache search result lists | Cache individual product details |
+| **Key** | `base64(query + supplier)` | `MD5(url + supplier + params)` |
+| **Stored data** | Array of serialized `ProductBuilder` snapshots | Single serialized `ProductBuilder` snapshot |
+| **Invalidation** | When requested limit exceeds cached limit | LRU eviction only |
+| **Written** | After `queryProducts()` returns results | After `getProductData()` fetches a product page |
+| **Max entries** | 100 | 100 |

--- a/wiki_files/Currency-and-Pricing.md
+++ b/wiki_files/Currency-and-Pricing.md
@@ -1,0 +1,77 @@
+# Currency & Pricing
+
+ChemPal supports multi-currency display with automatic exchange rate conversion, allowing users to compare prices across international suppliers in their preferred currency.
+
+## How It Works
+
+```mermaid
+flowchart LR
+subgraph Input["Raw Price from Supplier"]
+RAW["'$12.99' or '€45,00'\nor '¥1,200'"]
+end
+
+subgraph Parse["Price Parsing"]
+PP["parsePrice(price)\nExtracts amount + currency symbol"]
+SYM["getCurrencySymbol(price)\nDetects symbol from string"]
+CODE["getCurrencyCodeFromSymbol(symbol)\nMaps symbol → ISO code"]
+PP --> SYM --> CODE
+end
+
+subgraph Convert["Currency Conversion"]
+RATE["getCurrencyRate(from, to)\nHexarate API with LRU cache"]
+TOUSD["toUSD(amount, code)\nNormalize to USD"]
+FROMUSD["USDto(amount, targetCode)\nConvert to user's currency"]
+RATE --> TOUSD --> FROMUSD
+end
+
+subgraph Output["Displayed Price"]
+DISPLAY["Formatted in user's\nselected currency"]
+end
+
+Input --> Parse --> Convert --> Output
+
+classDef input fill:#5A7D8B,stroke:#3E5A66,color:#fff
+classDef parse fill:#2EAD6B,stroke:#1F7A4A,color:#fff
+classDef convert fill:#4A90D9,stroke:#2C5F8A,color:#fff
+classDef output fill:#E8A838,stroke:#B8841F,color:#fff
+
+class RAW input
+class PP,SYM,CODE parse
+class RATE,TOUSD,FROMUSD convert
+class DISPLAY output
+```
+
+## Supported Currencies
+
+| Code | Symbol | Location |
+|------|--------|----------|
+| USD | `$` | United States |
+| CAD | `CA$` | Canada |
+| GBP | `£` | United Kingdom |
+| AUD | `AU$` | Australia |
+| CNY | `¥` | China |
+| INR | `₹` | India |
+| RUB | `₽` | Russia |
+| EUR | `€` | Finland, Germany |
+
+## Key Functions
+
+Located in `src/helpers/currency.ts`:
+
+| Function | Description |
+|----------|-------------|
+| `parsePrice(price)` | Full price parsing — extracts numeric amount and detects currency |
+| `getCurrencySymbol(price)` | Extracts the currency symbol from a price string |
+| `getCurrencyRate(from, to)` | Fetches the exchange rate between two currencies (LRU cached, max 5 entries) |
+| `toUSD(amount, currencyCode)` | Converts an amount to USD |
+| `USDto(amount, currencyCode)` | Converts a USD amount to the target currency |
+| `getCurrencyCodeFromSymbol(symbol)` | Maps a currency symbol to its ISO code |
+| `getCurrencyCodeFromLocation(location)` | Maps a location code to the local currency |
+
+## Exchange Rate Source
+
+Rates are fetched from the [Hexarate API](https://hexarate.paikama.co) and cached using an in-memory LRU cache (max 5 entries) to avoid redundant API calls during a single session.
+
+## Price Parsing
+
+ChemPal uses the `price-parser` library (v3.4.0) for robust price extraction from varied supplier formats, supplemented by custom logic for currency symbol detection and normalization.

--- a/wiki_files/Getting-Started.md
+++ b/wiki_files/Getting-Started.md
@@ -1,0 +1,70 @@
+# Getting Started
+
+## Prerequisites
+
+- **Node.js** v22.15.0 or higher
+- **npm** v10.9.2 or higher
+- **pnpm** (installed globally)
+
+### Installing Node.js via NVM
+
+**macOS:**
+```bash
+brew install nvm
+# Follow the output instructions to update your ~/.bash_profile
+```
+
+**Windows:**
+Download the installer from [nvm-windows releases](https://github.com/coreybutler/nvm-windows/releases).
+
+**After NVM is installed:**
+```bash
+nvm install --lts
+nvm use --lts
+node --version   # Should output v22.15.0
+```
+
+### Installing pnpm
+
+```bash
+npm install -g pnpm
+```
+
+## Building the Extension
+
+```bash
+git clone https://github.com/jhyland87/chem-pal.git
+cd chem-pal
+pnpm run setup
+pnpm run build
+```
+
+The build output is written to the `build/` directory.
+
+## Loading in Chrome
+
+1. Open `chrome://extensions`
+2. Enable **Developer mode** (top right)
+3. Click **Load unpacked**
+4. Select the `build/` directory
+
+The extension will appear in your toolbar. Click the icon to open the popup, or use the side panel.
+
+## Development Scripts
+
+| Command | Description |
+|---------|-------------|
+| `pnpm run dev` | Start Vite dev server |
+| `pnpm run dev-mock` | Dev server with mocked API responses |
+| `pnpm run build` | Production build to `build/` |
+| `pnpm run build:aggregate` | Build with response capture enabled |
+| `pnpm run build:full` | Type-check + build |
+| `pnpm run test` | Run unit tests (Vitest, watch mode) |
+| `pnpm run test:run` | Run unit tests once |
+| `pnpm run test:e2e` | Run E2E tests (Playwright) |
+| `pnpm run test:coverage` | Run tests with coverage report |
+| `pnpm run test:ui` | Open Vitest UI with coverage |
+| `pnpm run docs` | Generate TypeDoc API documentation |
+| `pnpm run wwwdocs` | Serve generated docs on `localhost:8080` |
+| `pnpm run lint` | Run ESLint |
+| `pnpm run type-check` | Run TypeScript compiler (no emit) |

--- a/wiki_files/Home.md
+++ b/wiki_files/Home.md
@@ -1,4 +1,33 @@
-# Hello
+# ChemPal Wiki
 
+ChemPal is a Chrome extension for searching chemical suppliers and comparing product prices across 17+ vendors simultaneously. Built with React 19, TypeScript, and Vite, it streams results in real time as they arrive from each supplier.
 
-Test
+## Quick Links
+
+| Topic | Description |
+|-------|-------------|
+| [Getting Started](Getting-Started) | Prerequisites, installation, building, and loading the extension |
+| [Architecture Overview](Architecture-Overview) | High-level system design and data flow |
+| [Supplier System](Supplier-System) | How suppliers work, base classes, and adding new suppliers |
+| [Search Flow](Search-Flow) | End-to-end search execution from input to rendered results |
+| [Caching](Caching) | Chrome storage caching with LRU eviction |
+| [Currency & Pricing](Currency-and-Pricing) | Multi-currency support, exchange rates, and price parsing |
+| [PubChem Integration](PubChem-Integration) | Compound lookups, autocomplete, and SDQ queries |
+| [Settings & Configuration](Settings-and-Configuration) | User settings, supplier selection, and persistence |
+| [Testing](Testing) | Unit tests, E2E tests, mocking responses, and MSW setup |
+| [Project Structure](Project-Structure) | Directory layout and file organization |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| UI Framework | React 19 |
+| Language | TypeScript 5.8 |
+| Bundler | Vite 6 |
+| Component Library | MUI v7 (Material UI) |
+| Data Table | TanStack React Table 8 |
+| Package Manager | pnpm |
+| Unit Testing | Vitest + MSW |
+| E2E Testing | Vitest + Playwright |
+| API Docs | TypeDoc |
+| Extension Target | Chrome (Manifest v3) |

--- a/wiki_files/Project-Structure.md
+++ b/wiki_files/Project-Structure.md
@@ -1,0 +1,180 @@
+# Project Structure
+
+## Top-Level Layout
+
+```
+chem-pal/
+├── public/                  # Static assets and manifest.json
+│   ├── manifest.json        # Chrome extension manifest (v3)
+│   └── static/              # Icons, logos, images
+├── src/                     # Application source code
+│   ├── App.tsx              # Root component and state management
+│   ├── index.tsx            # Entry point
+│   ├── service-worker.js    # Extension service worker
+│   ├── components/          # React components
+│   ├── suppliers/           # Supplier implementations
+│   ├── types/               # TypeScript type definitions
+│   ├── utils/               # Utility classes
+│   ├── helpers/             # Helper functions
+│   ├── constants/           # Constants and enums
+│   ├── context/             # React context providers
+│   ├── features/            # Feature modules
+│   ├── shared/              # Shared components and hooks
+│   ├── styles/              # SCSS stylesheets
+│   ├── theme/               # Theme configuration
+│   └── __mocks__/           # MSW mock data
+├── e2e/                     # End-to-end tests
+├── tests/                   # Test utilities and mock data
+├── wiki_files/              # GitHub wiki source files
+├── pages/                   # Documentation pages (diagrams, guides)
+├── themes/                  # TypeDoc themes
+├── tools/                   # Build tools and scripts
+├── config.json              # App configuration (locations, currencies)
+├── vite.config.ts           # Vite build configuration
+├── vitest.config.ts         # Unit test configuration
+├── vitest.e2e.config.ts     # E2E test configuration
+├── typedoc.json             # TypeDoc configuration
+└── package.json             # Dependencies and scripts
+```
+
+## Source Code (`src/`)
+
+### Components (`src/components/`)
+
+```
+components/
+├── SearchPanel/             # Main search results interface
+│   ├── SearchPanel.tsx      # Container component
+│   ├── SearchInput.tsx      # Search query input
+│   ├── ResultsTable.tsx     # TanStack data table with filters
+│   ├── TableColumns.tsx     # Column definitions
+│   ├── TableHeader.tsx      # Header controls
+│   ├── TableOptions.tsx     # Table options menu
+│   ├── FilterMenu.tsx       # Advanced filtering
+│   ├── ContextMenu.tsx      # Right-click context menu
+│   ├── Pagination.tsx       # Result pagination
+│   ├── hooks/               # Panel-specific hooks
+│   │   ├── useAutoColumnSizing.hook.ts
+│   │   ├── useContextMenu.hook.ts
+│   │   ├── useFilterMenu.hook.ts
+│   │   ├── useResultsTable.hook.ts
+│   │   └── useSearchInput.hook.ts
+│   └── Inputs/              # Filter input components
+│       ├── ColumnVisibilitySelect.tsx
+│       ├── RangeColumnFilter.tsx
+│       ├── SelectColumnFilter.tsx
+│       ├── TextColumnFilter.tsx
+│       └── SupplierResultLimit.tsx
+├── SettingsPanel.tsx         # Popup settings panel
+├── SettingsPanelFull.tsx     # Full-page settings
+├── SuppliersPanel.tsx        # Supplier enable/disable
+├── StatsPanel.tsx            # Search statistics
+├── DrawerSystem.tsx          # Drawer-based navigation
+├── FavoritesPanel.tsx        # Saved favorites
+├── HistoryPanel.tsx          # Search history
+├── SpeedDialMenu.tsx         # FAB speed dial
+├── ThemeProvider.tsx          # Theme context
+├── ThemeSwitcher.tsx          # Theme toggle
+├── StyledComponents.ts       # MUI styled components
+├── ErrorBoundary.tsx          # Error boundary
+├── LoadingBackdrop.tsx        # Loading overlay
+└── HelpTooltip.tsx            # Contextual help tooltips
+```
+
+### Suppliers (`src/suppliers/`)
+
+```
+suppliers/
+├── index.ts                  # Barrel export of all active suppliers
+├── SupplierBase.ts           # Abstract base class
+├── SupplierFactory.ts        # Parallel execution orchestrator
+├── SupplierBaseWix.ts        # Wix platform base
+├── SupplierBaseShopify.ts    # Shopify platform base
+├── SupplierBaseWoocommerce.ts # WooCommerce platform base
+├── SupplierBaseAmazon.ts     # Amazon platform base
+├── SupplierAmbeed.ts         # Ambeed
+├── SupplierBiofuranChem.ts   # BioFuranChem
+├── SupplierCarolina.ts       # Carolina Biological
+├── SupplierCarolinaChemical.ts
+├── SupplierChemsavers.ts
+├── SupplierFtfScientific.ts
+├── SupplierHbarSci.ts
+├── SupplierHimedia.ts
+├── SupplierInnovatingScience.ts
+├── SupplierLaballey.ts
+├── SupplierLaboratoriumDiscounter.ts
+├── SupplierLibertySci.ts
+├── SupplierLoudwolf.ts
+├── SupplierMacklin.ts
+├── SupplierOnyxmet.ts
+├── SupplierSynthetika.ts
+├── SupplierWarchem.ts
+├── __tests__/                # Supplier tests
+├── __mocks__/                # Supplier mocks
+└── __fixtures__/             # Test fixtures
+```
+
+### Utilities (`src/utils/`)
+
+| File | Description |
+|------|-------------|
+| `Logger.ts` | Structured logging with per-supplier prefixes |
+| `ProductBuilder.ts` | Fluent product construction with validation and serialization |
+| `Pubchem.ts` | PubChem API client |
+| `SupplierCache.ts` | Chrome storage caching with LRU eviction |
+| `SupplierStatsStore.ts` | Per-supplier success/failure/timing statistics |
+| `Cactus.ts` | NCI/CADD Chemical Identifier Resolver utility |
+| `BadgeAnimator.ts` | Extension badge animations |
+| `HttpLru.ts` | In-memory LRU cache for HTTP requests |
+| `fetchDecorator.ts` | Enhanced fetch wrapper with response capture |
+
+### Helpers (`src/helpers/`)
+
+| File | Description |
+|------|-------------|
+| `currency.ts` | Currency conversion, rate fetching, price parsing |
+| `pubchem.ts` | PubChem type guards and assertion functions |
+| `quantity.ts` | Quantity string parsing and formatting |
+| `cas.ts` | CAS number validation and parsing |
+| `fetch.ts` | Enhanced fetch with request hashing |
+| `request.ts` | HTTP request utilities |
+| `responseAggregate.ts` | Response capture for test mock generation |
+| `utils.ts` | General utilities (sorting, collections) |
+| `science.ts` | Chemistry-specific helpers |
+| `collectionUtils.ts` | Array and collection operations |
+| `history.ts` | Search history management |
+
+### Types (`src/types/`)
+
+| File | Description |
+|------|-------------|
+| `product.d.ts` | Core types: `Product`, `ISupplier`, `UserSettings`, `QuantityObject` |
+| `pubchem.d.ts` | PubChem SDQ API types |
+| `currency.d.ts` | Currency conversion types |
+| `cas.d.ts` | CAS number types |
+| `settings.d.ts` | Settings action types |
+| `chromeStorage.d.ts` | Chrome storage types |
+| `datetime.d.ts` | Date/time utility types |
+| `tanstack.d.ts` | TanStack React Table extensions |
+| `props.d.ts` | React component prop types |
+| Supplier-specific: | `carolina.d.ts`, `ambeed.d.ts`, `macklin.d.ts`, `shopify.d.ts`, `wix.d.ts`, `woocommerce.d.ts`, etc. |
+
+### Shared (`src/shared/`)
+
+```
+shared/
+├── components/               # Reusable UI components
+│   ├── AboutModal/
+│   ├── Debounce/
+│   ├── ErrorBoundary/
+│   ├── HelpTooltip/
+│   ├── IconTextFader/
+│   ├── LoadingBackdrop/
+│   ├── SuppliersPanel/
+│   ├── TabLink/
+│   └── TabPanel/
+└── hooks/                    # Reusable hooks
+    ├── useDebouncedCallback.hook.ts
+    ├── useHelpTooltip.hook.ts
+    └── index.ts
+```

--- a/wiki_files/PubChem-Integration.md
+++ b/wiki_files/PubChem-Integration.md
@@ -1,0 +1,86 @@
+# PubChem Integration
+
+ChemPal integrates with the [PubChem API](https://pubchem.ncbi.nlm.nih.gov/) for compound lookups, search suggestions, and chemical name resolution.
+
+## Use Cases
+
+```mermaid
+flowchart TB
+subgraph Triggers["When PubChem is Used"]
+direction TB
+T1["Search returns no results\n→ suggest alternative compound names"]
+T2["Autocomplete in search input\n→ compound name suggestions"]
+T3["CAS number / compound ID lookup\n→ resolve aliases"]
+end
+
+subgraph API["PubChem API Calls"]
+direction TB
+AC["/rest/autocomplete/compound/{name}\nCompound name autocomplete"]
+CID["/rest/pug/concepts/name/JSON\nCompound ID lookup"]
+SDQ["/sdq/sdqagent.cgi\nStructure Data Query agent"]
+end
+
+subgraph Results["Output"]
+direction TB
+R1["Suggested search terms\ndisplayed to user"]
+R2["Compound metadata\nCID, synonyms, properties"]
+end
+
+T1 --> SDQ --> R2
+T2 --> AC --> R1
+T3 --> CID --> R2
+
+classDef trigger fill:#5A7D8B,stroke:#3E5A66,color:#fff
+classDef api fill:#4A90D9,stroke:#2C5F8A,color:#fff
+classDef result fill:#27AE60,stroke:#1E8449,color:#fff
+
+class T1,T2,T3 trigger
+class AC,CID,SDQ api
+class R1,R2 result
+```
+
+## API Methods
+
+Located in `src/utils/Pubchem.ts`:
+
+| Method | API Endpoint | Description |
+|--------|-------------|-------------|
+| `getCompound(name)` | `/rest/autocomplete/compound/{name}` | Autocomplete lookup for compound names |
+| `getCID(name)` | `/rest/pug/concepts/name/JSON?name={name}` | Get the PubChem Compound ID (CID) |
+| `querySdqAgent(query)` | `/sdq/sdqagent.cgi` | Query the SDQ agent for compound data |
+| `getSimpleName(name)` | Derived from above | Get the simplified/common compound name |
+| `getCompoundNameFromAlias(synonym)` | Derived from above | Resolve a synonym to its canonical name |
+
+## SDQ Query Types
+
+The SDQ (Structure Data Query) agent supports querying across multiple PubChem collections:
+
+- `compound` — Chemical compounds
+- `substance` — Substance records
+- `pubmed` — Related publications
+- `patent` — Patent references
+
+## Type Definitions
+
+Located in `src/types/pubchem.d.ts`:
+
+| Type | Description |
+|------|-------------|
+| `SDQCollection` | Union of queryable collection types |
+| `SDQResponse` | Full response envelope from SDQ agent |
+| `SDQOutputSet` | Individual output set containing compound information |
+| `SDQResultItem` | Individual compound data row (100+ properties) |
+| `SDQAgentQuery` | Query parameters for the SDQ agent |
+| `SDQQuery` | Query parameters for SDQ lookups |
+| `CompoundResponse` | Autocomplete response structure |
+| `CIDResponse` | Compound ID lookup response structure |
+
+## Helper Functions
+
+Located in `src/helpers/pubchem.ts`, these provide type guards and assertion functions for validating PubChem API responses:
+
+- `assertIsSDQResponse(data)` — Asserts data is a valid `SDQResponse`
+- `assertIsSDQWhere(where)` — Asserts data is a valid `SDQWhere`
+- `assertIsCIDResponse(data)` — Asserts data is a valid `CIDResponse`
+- `assertIsCompoundResponseResponse(data)` — Asserts data is a valid `CompoundResponse`
+- `assertIsSdqAgentResponse(data)` — Asserts data is a valid SDQ agent response

--- a/wiki_files/Search-Flow.md
+++ b/wiki_files/Search-Flow.md
@@ -1,0 +1,147 @@
+# Search Flow
+
+This page details the end-to-end search flow from user input through to rendered results, including how the search execution layer orchestrates multiple suppliers in parallel via streaming.
+
+## Key Concepts
+
+- **Two entry points**: `SearchPage` (web app) and `SearchPanelHome` (Chrome extension) both feed into the same execution pipeline
+- **Streaming results**: `SupplierFactory.executeAllStream()` yields products as they arrive from any supplier, enabling incremental UI updates
+- **Session persistence**: The Chrome extension persists query state and results to `chrome.storage.session` for restore-on-mount
+- **Supplier data strategies**: Each supplier implements one of three patterns depending on what the vendor's site exposes:
+  - **JSON Only** (e.g. Wix) — GraphQL/REST API provides all product data in the search response; no detail page fetch needed
+  - **HTML Only** (e.g. Loudwolf) — Both search results and product details are scraped from HTML pages via `DOMParser`
+  - **Hybrid** (e.g. Onyxmet) — Search results come from a JSON endpoint, but product details require scraping the HTML product page
+
+## Diagram
+
+```mermaid
+flowchart TB
+
+subgraph Entry["Entry Points"]
+direction LR
+SP["SearchPage\n(Web App)"]
+SPH["SearchPanelHome\n(Chrome Extension)"]
+end
+
+SP -->|"onSearch(query)"| SF["SearchForm"]
+SPH -->|"onSearch(query)"| SF
+
+subgraph InputLayer["UI Input Layer"]
+SF
+SI["SearchInput\n(alternative input)"]
+USI["useSearchInput Hook\nmanages input state and\nchrome.storage.session persistence"]
+SI --- USI
+end
+
+SF -->|"query string"| ES
+SI -->|"query string"| ES
+
+subgraph Execution["Search Execution Layer"]
+ES["executeSearch(query)\nuseSearch hook"]
+ES -->|"startTransition"| PS["performSearch()"]
+PS -->|"1. Instantiate"| SFACT["SupplierFactory\nnew SupplierFactory(query, limit, controller, suppliers?)"]
+SFACT -->|"2. Stream results"| STREAM["executeAllStream(concurrency=3)\nAsyncGenerator - yields products\nas they arrive from any supplier"]
+STREAM -->|"for await (product)"| PROCESS["Process Each Result\nupdate resultCount\nappend to searchResults\nsave to chrome.storage.session"]
+end
+
+CHROME[("chrome.storage.session\nquery, isNewSearch flag,\npersisted results")]
+SPH -.->|"save query + isNewSearch flag"| CHROME
+CHROME -.->|"load on mount\nif isNewSearch then performSearch"| ES
+PROCESS -.->|"save incrementally"| CHROME
+
+subgraph Factory["SupplierFactory"]
+direction TB
+SFACT2["Instantiate selected suppliers\nfrom supplier index module"]
+QUEUE["async-await-queue\nparallel execution with\nconcurrency limit"]
+CHAN["Channel array\ncollect yielded products\nfrom all suppliers"]
+SFACT2 --> QUEUE --> CHAN
+end
+STREAM -.-> Factory
+
+CHAN -->|"per supplier"| EXEC
+
+subgraph SupplierPipeline["SupplierBase.execute - AsyncGenerator Pipeline"]
+direction TB
+EXEC["execute()"]
+SETUP["setup()\nsupplier-specific init\nauth tokens, headers, etc."]
+QPC["queryProductsWithCache()\ncheck chrome.storage.local cache\nfallback to queryProducts()"]
+QP["queryProducts()\nfetch search results\nsupplier-specific"]
+FUZZ["fuzzyFilter()\nfuzzball WRatio scorer\nvia titleSelector()"]
+IPB["initProductBuilders()\nparse raw data into\nProductBuilder instances"]
+EXEC --> SETUP --> QPC
+QPC -->|"cache miss"| QP
+QP --> FUZZ --> IPB
+subgraph DetailFetch["Product Detail Fetching - concurrent via async-await-queue"]
+direction TB
+GPDC["getProductDataWithCache()\nper product"]
+GPD["getProductData()\nfetch individual product page\nsupplier-specific"]
+FP["finishProduct()\nvalidate, set country/shipping,\ncall product.build()"]
+GPDC -->|"cache miss"| GPD --> FP
+end
+IPB -->|"for each product builder"| DetailFetch
+FP -->|"yield product"| YIELD(("yield"))
+end
+
+subgraph Strategies["Supplier Data Strategies"]
+direction TB
+subgraph JSONOnly["JSON Only - e.g. Wix Suppliers"]
+direction TB
+WS["setup: fetch Wix access token\nGET /_api/v1/access-tokens"]
+WQ["queryProducts: GraphQL API call\nPOST /ecom query"]
+WI["initProductBuilders:\nparse JSON product nodes"]
+WG["getProductData: no-op\nall data already available"]
+WS --> WQ --> WI --> WG
+end
+subgraph HTMLOnly["HTML Only - e.g. Loudwolf"]
+direction TB
+LQ["queryProducts: fetch search page\nGET /storefront/?search=..."]
+LF["fuzzHtmlResponse:\nDOMParser + querySelectorAll\nfuzzy filter by title"]
+LI["initProductBuilders:\nscrape price, URL, ID"]
+LG["getProductData: fetch product page\nparse for CAS, quantity, grade"]
+LQ --> LF --> LI --> LG
+end
+subgraph Hybrid["Hybrid JSON + HTML - e.g. Onyxmet"]
+direction TB
+OQ["queryProducts: fetch JSON endpoint\nGET index.php?term=..."]
+OF["fuzzyFilter:\nfilter JSON results by label"]
+OI["initProductBuilders:\nmap JSON items to builders"]
+OG["getProductData: fetch product HTML\nscrape price, availability, CAS"]
+OQ --> OF --> OI --> OG
+end
+end
+
+QP -.->|"JSON path"| JSONOnly
+QP -.->|"HTML path"| HTMLOnly
+QP -.->|"Hybrid path"| Hybrid
+
+YIELD -->|"streamed back through\nexecuteAllStream"| PROCESS
+PROCESS --> RT["ResultsTable\nSearchPanel renders table\nwith column filters"]
+
+PROCESS -->|"if no results"| PUBCHEM["PubChem API\nsuggest alternative\nsearch terms"]
+
+classDef entry fill:#4A90D9,stroke:#2C5F8A,color:#fff,font-weight:bold
+classDef input fill:#5BA3CF,stroke:#3A7CA5,color:#fff
+classDef exec fill:#4A90D9,stroke:#2C5F8A,color:#fff
+classDef factory fill:#6B8E9B,stroke:#4A6B78,color:#fff
+classDef pipeline fill:#5A7D8B,stroke:#3E5A66,color:#fff
+classDef json fill:#2EAD6B,stroke:#1F7A4A,color:#fff
+classDef html fill:#D97B2A,stroke:#A35D1F,color:#fff
+classDef hybrid fill:#9B59B6,stroke:#6F3D8A,color:#fff
+classDef storage fill:#E8A838,stroke:#B8841F,color:#fff
+classDef output fill:#3498DB,stroke:#2176AC,color:#fff
+classDef fallback fill:#95A5A6,stroke:#6E7B7C,color:#fff
+classDef yieldNode fill:#27AE60,stroke:#1E8449,color:#fff
+
+class SP,SPH entry
+class SF,SI,USI input
+class ES,PS,SFACT,STREAM,PROCESS exec
+class SFACT2,QUEUE,CHAN factory
+class EXEC,SETUP,QPC,QP,FUZZ,IPB,GPDC,GPD,FP pipeline
+class WS,WQ,WI,WG json
+class LQ,LF,LI,LG html
+class OQ,OF,OI,OG hybrid
+class CHROME storage
+class RT output
+class PUBCHEM fallback
+class YIELD yieldNode
+```

--- a/wiki_files/Settings-and-Configuration.md
+++ b/wiki_files/Settings-and-Configuration.md
@@ -1,0 +1,91 @@
+# Settings & Configuration
+
+## User Settings
+
+User settings are managed via React 19's `useActionState` and persisted to Chrome storage. The settings UI is available through the drawer navigation.
+
+### Available Settings
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `caching` | `boolean` | Enable/disable supplier result caching |
+| `autocomplete` | `boolean` | Enable search input autocomplete suggestions |
+| `currency` | `CurrencyCode` | Preferred currency for price display |
+| `location` | `CountryCode` | User's geographic location |
+| `shipsToMyLocation` | `boolean` | Filter results to suppliers that ship to your location |
+| `suppliers` | `string[]` | List of enabled supplier class names |
+| `theme` | `string` | UI theme selection |
+| `showHelp` | `boolean` | Show help tooltips |
+| `showColumnFilters` | `boolean` | Show column filter inputs in results table |
+| `columnFilterConfig` | `object` | Per-column filter configuration |
+| `hideColumns` | `string[]` | Columns hidden from the results table |
+| `supplierResultLimit` | `number` | Maximum results per supplier |
+
+### Setting Actions
+
+Settings changes are dispatched as actions through a reducer:
+
+| Action | Trigger |
+|--------|---------|
+| `SWITCH_CHANGE` | Toggle switches (caching, autocomplete, etc.) |
+| `INPUT_CHANGE` | Text/select inputs (currency, location, etc.) |
+| `BUTTON_CLICK` | Button actions (e.g. clear cache) |
+| `RESTORE_DEFAULTS` | Reset all settings to defaults |
+
+## State Architecture
+
+```mermaid
+flowchart TB
+subgraph Components["UI Components"]
+SP["SettingsPanel\n(popup)"]
+SPF["SettingsPanelFull\n(full page)"]
+SUP["SuppliersPanel\n(supplier toggle)"]
+end
+
+subgraph State["State Management"]
+AR["useActionState\n(React 19 reducer)"]
+CTX["AppContext\n(global provider)"]
+end
+
+subgraph Persistence["Persistence"]
+CS[("chrome.storage\nsync settings")]
+end
+
+SP --> AR
+SPF --> AR
+SUP --> AR
+AR --> CTX
+AR -.->|"auto-persist"| CS
+CS -.->|"load on mount"| AR
+
+classDef component fill:#4A90D9,stroke:#2C5F8A,color:#fff
+classDef state fill:#27AE60,stroke:#1E8449,color:#fff
+classDef storage fill:#E8A838,stroke:#B8841F,color:#fff
+
+class SP,SPF,SUP component
+class AR,CTX state
+class CS storage
+```
+
+## Supported Locations
+
+Configured in `config.json`:
+
+| Code | Country | Default Currency |
+|------|---------|-----------------|
+| US | United States | USD |
+| CA | Canada | CAD |
+| UK | United Kingdom | GBP |
+| AU | Australia | AUD |
+| NZ | New Zealand | NZD |
+| JP | Japan | JPY |
+| CN | China | CNY |
+| IN | India | INR |
+| RU | Russia | RUB |
+| FIN | Finland | EUR |
+| DE | Germany | EUR |
+| OTHER | Other | USD |
+
+## Supplier Selection
+
+Users can enable/disable individual suppliers through the Suppliers panel. Only enabled suppliers are queried during search. The selection is passed to `SupplierFactory` which filters accordingly.

--- a/wiki_files/Supplier-System.md
+++ b/wiki_files/Supplier-System.md
@@ -1,0 +1,134 @@
+# Supplier System
+
+ChemPal aggregates results from 17 active chemical supplier websites. Each supplier is a class that extends `SupplierBase` and implements a standardized lifecycle for searching, parsing, and yielding products.
+
+## Active Suppliers
+
+| Supplier | Platform | Country | Data Strategy |
+|----------|----------|---------|---------------|
+| Ambeed | Custom | US | Hybrid (JSON search + HTML detail) |
+| BioFuranChem | Wix | US | JSON Only |
+| Carolina | Oracle ATG | US | JSON Only |
+| Carolina Chemical | Custom | US | HTML Only |
+| ChemSavers | Shopify | US | Hybrid |
+| FTF Scientific | WooCommerce | US | Hybrid |
+| H-Bar Scientific | Wix | US | JSON Only |
+| HiMedia | Custom | IN | Hybrid |
+| Innovating Science | Wix | US | JSON Only |
+| Lab Alley | Shopify | US | Hybrid |
+| Laboratorium Discounter | Custom | NL | Hybrid |
+| Liberty Science | Custom | US | HTML Only |
+| Loudwolf | Custom | US | HTML Only |
+| Macklin | Custom | CN | JSON Only |
+| Onyxmet | Custom | PL | Hybrid (JSON search + HTML detail) |
+| Synthetika | Custom | EU | Hybrid |
+| Warchem | Custom | PL | Hybrid |
+
+## Data Strategies
+
+Suppliers follow one of three patterns depending on what the vendor exposes:
+
+### JSON Only
+The search API returns all product data (title, price, quantity, CAS, etc.) in a single response. No detail page fetch is required.
+- Examples: Wix-based suppliers, Carolina, Macklin
+
+### HTML Only
+Both search results and product details are scraped from HTML pages using `DOMParser`.
+- Examples: Loudwolf, Carolina Chemical, Liberty Science
+
+### Hybrid (JSON + HTML)
+Search results come from a JSON/API endpoint, but full product details require fetching and scraping the individual product page.
+- Examples: Onyxmet, Ambeed, ChemSavers, Lab Alley
+
+## Supplier Lifecycle
+
+Every supplier follows this execution pipeline, defined in `SupplierBase.execute()`:
+
+```
+setup()
+  │   Supplier-specific initialization (auth tokens, headers, etc.)
+  ▼
+queryProductsWithCache(query, limit)
+  │   Check chrome.storage.local cache → fallback to queryProducts()
+  ▼
+queryProducts(query, limit)
+  │   Fetch search results from the supplier's website
+  ▼
+fuzzyFilter()
+  │   Apply fuzzball WRatio scoring via titleSelector() to filter irrelevant results
+  ▼
+initProductBuilders()
+  │   Parse raw results into ProductBuilder instances
+  ▼
+┌─ for each ProductBuilder ──────────────────┐
+│  getProductDataWithCache(product)           │
+│    │   Check cache → fallback to           │
+│    ▼   getProductData(product)             │
+│  finishProduct()                           │
+│    │   Validate, set country/shipping,     │
+│    ▼   call product.build()                │
+│  yield product  ◄── back to caller         │
+└────────────────────────────────────────────┘
+```
+
+## Platform Base Classes
+
+Common e-commerce platforms have shared base classes that handle platform-specific boilerplate:
+
+| Base Class | File | Handles |
+|------------|------|---------|
+| `SupplierBaseWix` | `SupplierBaseWix.ts` | Wix access token flow, GraphQL product queries |
+| `SupplierBaseShopify` | `SupplierBaseShopify.ts` | Shopify storefront API, product JSON parsing |
+| `SupplierBaseWoocommerce` | `SupplierBaseWoocommerce.ts` | WooCommerce REST API product queries |
+| `SupplierBaseAmazon` | `SupplierBaseAmazon.ts` | Amazon product page scraping (currently unused) |
+
+## SupplierFactory
+
+`SupplierFactory` orchestrates parallel execution of multiple suppliers:
+
+```typescript
+const factory = new SupplierFactory("sodium chloride", 5, controller, ["SupplierCarolina"]);
+
+for await (const product of factory) {
+  console.log(product.supplier, product.title, product.price);
+}
+```
+
+- Uses `async-await-queue` with a configurable concurrency limit (default: 3)
+- Implements `AsyncGenerator` — yields products as they stream in from any supplier
+- Accepts an `AbortController` for cancellation
+- Optionally filters to a subset of suppliers by class name
+
+## Adding a New Supplier
+
+1. Create `src/suppliers/SupplierMyVendor.ts`
+2. Extend the appropriate base class (`SupplierBase`, or a platform base like `SupplierBaseShopify`)
+3. Implement required abstract members:
+   - `supplierName`, `baseURL`, `shipping`, `country`, `paymentMethods`
+   - `queryProducts()` — fetch and return raw search results
+   - `initProductBuilders()` — convert raw results to `ProductBuilder` instances
+   - `getProductData()` — fetch individual product details (can be a no-op for JSON Only)
+   - `titleSelector()` — return the product title for fuzzy matching
+4. Export from `src/suppliers/index.ts`
+5. The supplier will automatically appear in the SupplierFactory and settings UI
+
+## ProductBuilder
+
+Products are constructed using `ProductBuilder`, a fluent builder that enforces required fields:
+
+```typescript
+const product = new ProductBuilder(baseURL)
+  .setTitle("Sodium Chloride")
+  .setPrice("$12.99")
+  .setQuantity("500g")
+  .setCas("7647-14-5")
+  .setSupplier("MyVendor")
+  .setUrl("/products/nacl")
+  .build();
+```
+
+`ProductBuilder` also handles:
+- Serialization (`dump()`) and deserialization (`createFromCache()`) for caching
+- Price parsing and currency detection
+- Quantity normalization
+- Validation of required fields before `build()`

--- a/wiki_files/Testing.md
+++ b/wiki_files/Testing.md
@@ -1,0 +1,161 @@
+# Testing
+
+ChemPal uses Vitest for both unit and E2E testing, with Mock Service Worker (MSW) for API mocking and Playwright for browser-based E2E tests.
+
+## Test Configuration
+
+| Config | File | Environment | Purpose |
+|--------|------|-------------|---------|
+| Unit tests | `vitest.config.ts` | jsdom | Component and utility tests |
+| E2E tests | `vitest.e2e.config.ts` | node | Full browser tests via Playwright |
+
+### Unit Test Settings
+- **Pool**: vmThreads (max 4, min 1)
+- **Globals**: enabled
+- **Setup**: `vitest.setup.ts`
+- **Pattern**: `src/**/__tests__/**/*.{test,spec}.{js,ts,jsx,tsx}`
+
+### E2E Test Settings
+- **Pool**: single fork
+- **Timeout**: 60 seconds
+- **Pattern**: `e2e/**/*.e2e.test.ts`
+
+## Running Tests
+
+```bash
+# Watch mode
+pnpm run test
+
+# Single run
+pnpm run test:run
+
+# With coverage
+pnpm run test:coverage
+
+# With Vitest UI
+pnpm run test:ui
+
+# E2E tests
+pnpm run test:e2e
+```
+
+## Test File Locations
+
+| Directory | Contents |
+|-----------|----------|
+| `src/__tests__/` | App-level tests |
+| `src/components/__tests__/` | Component tests |
+| `src/suppliers/__tests__/` | Supplier tests |
+| `src/helpers/__tests__/` | Helper function tests |
+| `src/utils/__tests__/` | Utility class tests |
+| `src/mixins/__tests__/` | Mixin tests |
+| `e2e/` | End-to-end tests with Playwright |
+
+## Mocking API Responses
+
+ChemPal captures real HTTP responses and replays them during testing. This ensures tests run against realistic data without hitting live supplier sites.
+
+### Mock Response File Format
+
+Each captured response is stored as a JSON file:
+
+```
+responses/
+  {hostname}/
+    {hash}.json
+```
+
+Each file contains:
+
+```json
+{
+  "contentType": "application/json",
+  "content": "JTdCJTIycmVzdWx0cyUyMiUzQS4uLiU3RA=="
+}
+```
+
+- **`contentType`** — MIME type of the original response
+- **`content`** — Response body encoded as `btoa(encodeURIComponent(body))`
+
+### Hash Generation
+
+The filename hash is `MD5(method + pathname + search + body)`:
+
+```
+md5("GET" + "/browse/product-search-results" + "?tab=p&format=json&q=acid" + "")
+```
+
+Computed by `getRequestHash()` in `src/helpers/request.ts` (browser) and `e2e/helpers/requestHash.ts` (Node.js).
+
+### Capturing New Responses
+
+```mermaid
+flowchart LR
+subgraph Step1["1. Build"]
+B["pnpm build:aggregate\nEnables __RESPONSE_AGGREGATE__ flag"]
+end
+
+subgraph Step2["2. Use Extension"]
+L["Load unpacked build/\nin Chrome"]
+S["Run searches to\ncapture responses"]
+end
+
+subgraph Step3["3. Download"]
+C["DevTools Console:\nwindow.__responseAggregate.download()"]
+end
+
+subgraph Step4["4. Extract"]
+E["unzip to\ntests/mock-requests/responses/"]
+end
+
+Step1 --> Step2 --> Step3 --> Step4
+
+classDef step fill:#4A90D9,stroke:#2C5F8A,color:#fff
+class B,L,S,C,E step
+```
+
+**Detailed steps:**
+
+1. **Build in aggregate mode**: `pnpm build:aggregate`
+2. **Load the extension** in Chrome (`chrome://extensions` → Load unpacked → `build/`)
+3. **Run searches** to capture responses (multiple queries accumulate in one session)
+4. **Download** via DevTools console:
+   ```js
+   window.__responseAggregate.list()    // See captured requests
+   window.__responseAggregate.count     // Count
+   window.__responseAggregate.download() // Download as zip
+   window.__responseAggregate.clear()   // Reset
+   ```
+5. **Extract**: `unzip ~/Downloads/response-aggregate-*.zip -d tests/mock-requests/responses/`
+
+### Using Mocks in Tests
+
+**Unit tests (MSW):**
+
+Mock files in `src/__mocks__/responses/` are automatically loaded by the MSW handlers in `src/__mocks__/handlers.ts`.
+
+```bash
+# Copy captured responses for unit tests
+cp -r tests/mock-requests/responses/* src/__mocks__/responses/
+```
+
+**E2E tests (Playwright):**
+
+```typescript
+import { setupMockRoutes } from "../helpers/mockRoutes";
+
+test("search for acid returns mocked results", async ({ page }) => {
+  await setupMockRoutes(page, {
+    responsesDir: "tests/mock-requests/responses",
+    fallback: "abort", // fail if no mock found (default)
+  });
+
+  // ... interact with extension, all HTTPS requests will be mocked
+});
+```
+
+### Tips
+
+- **Multiple queries**: Run multiple searches in aggregate mode before downloading — all responses accumulate
+- **Updating mocks**: Re-run the aggregate flow for fresh responses. Hash-based naming means unchanged requests produce the same filenames
+- **Debugging**: If a test fails with a missing mock, check the test output for the expected hash and verify the file exists

--- a/wiki_files/_Sidebar.md
+++ b/wiki_files/_Sidebar.md
@@ -1,0 +1,23 @@
+## ChemPal Wiki
+
+- [Home](Home)
+
+**Getting Started**
+- [Getting Started](Getting-Started)
+- [Project Structure](Project-Structure)
+
+**Architecture**
+- [Architecture Overview](Architecture-Overview)
+- [Search Flow](Search-Flow)
+- [Caching](Caching)
+
+**Suppliers**
+- [Supplier System](Supplier-System)
+
+**Features**
+- [Currency & Pricing](Currency-and-Pricing)
+- [PubChem Integration](PubChem-Integration)
+- [Settings & Configuration](Settings-and-Configuration)
+
+**Development**
+- [Testing](Testing)


### PR DESCRIPTION
Creates 11 wiki pages covering architecture, supplier system, search flow, caching, currency/pricing, PubChem integration, settings, testing, project structure, and getting started. All diagrams use Mermaid for native GitHub rendering. Sidebar navigation included.