### PR TITLE
Add release workflow for tag-triggered .crx publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,216 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to release (e.g. v0.0.13 or v0.0.13-beta.3)'
+        required: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_VERSION: 'v22.15.0'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build the app
+        run: pnpm run build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-output
+          path: build/
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run unit tests
+        run: ulimit -n 65536 && pnpm run test
+
+  test-e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: build/
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: xvfb-run --auto-servernum -- pnpm run test:e2e
+
+  release:
+    needs: [test, test-e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Resolve version from tag or input
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.version }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+
+          # Strip leading v for the human-readable version_name
+          VERSION_NAME="${TAG#v}"
+
+          # Chrome's manifest.version must be 1-4 dot-separated integers — strip any prerelease suffix
+          VERSION=$(echo "$VERSION_NAME" | grep -oE '^[0-9]+(\.[0-9]+){0,3}' || true)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract numeric version from tag: $TAG"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "Releasing tag=$TAG version=$VERSION version_name=$VERSION_NAME"
+
+      - name: Apply version to package.json and manifest.json
+        run: |
+          jq --arg v "${{ steps.version.outputs.version_name }}" \
+            '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          jq --arg v "${{ steps.version.outputs.version }}" \
+             --arg vn "${{ steps.version.outputs.version_name }}" \
+            '.version = $v | .version_name = $vn' public/manifest.json > public/manifest.json.tmp
+          mv public/manifest.json.tmp public/manifest.json
+
+      - name: Write signing key
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          if [ -z "$CRX_PRIVATE_KEY" ]; then
+            echo "::error::CRX_PRIVATE_KEY secret is not set"
+            exit 1
+          fi
+          printf '%s\n' "$CRX_PRIVATE_KEY" > chem-pal.pem
+          chmod 600 chem-pal.pem
+
+      - name: Build production extension
+        run: pnpm run build:prod
+
+      - name: Verify .crx output
+        run: |
+          if [ ! -f chem-pal.crx ]; then
+            echo "::error::chem-pal.crx not produced by build:prod"
+            exit 1
+          fi
+          ls -lh chem-pal.crx
+
+      - name: Zip unpacked build
+        run: |
+          cd build && zip -r "../chem-pal-${{ steps.version.outputs.version_name }}-unpacked.zip" . && cd ..
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # On workflow_dispatch the tag may not exist yet — let gh create it at the current commit
+          EXTRA_ARGS=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            EXTRA_ARGS="--target ${{ github.sha }}"
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            $EXTRA_ARGS \
+            chem-pal.crx \
+            "chem-pal-${{ steps.version.outputs.version_name }}-unpacked.zip"
+
+      - name: Always remove signing key
+        if: always()
+        run: rm -f chem-pal.pem

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ coverage
 build.pem
 ChemPal.pem
 chem-pal.pem
+*.crx

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing
+
+Releases are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml). Pushing a `v*` tag (or running the workflow manually) builds the production extension, signs it, and publishes a GitHub Release with the `.crx` and an unpacked-build zip attached.
+
+## Prerequisites
+
+- **`CRX_PRIVATE_KEY` repo secret.** The PEM private key used to sign the `.crx`. Settings → Secrets and variables → Actions → New repository secret. Paste the full PEM, including the `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines and the trailing newline.
+  - The same key must be used for every release — Chrome derives the extension's identity from it. Losing or replacing it produces a different extension ID.
+
+## Cutting a release
+
+1. **Pick a version.** The tag drives everything. Format: `v<major>.<minor>.<patch>` for stable, or `v<major>.<minor>.<patch>-<prerelease>` for betas (e.g. `v0.0.13`, `v0.0.13-beta.4`).
+
+2. **Bump `package.json` to match.** Set `version` to the same string (without the leading `v`). Commit it on `main`. This keeps `main` in sync with what's been released — the workflow will overwrite `package.json` and `public/manifest.json` on the runner regardless, but only for the build artifact.
+
+   ```bash
+   # edit package.json: "version": "0.0.13-beta.4"
+   git commit -am "Bump to 0.0.13-beta.4"
+   git push
+   ```
+
+3. **Tag and push.**
+
+   ```bash
+   git tag v0.0.13-beta.4
+   git push origin v0.0.13-beta.4
+   ```
+
+4. **Watch the run.** The release workflow runs `build → (test + test-e2e in parallel) → release`. The release job only runs if both test suites pass. Watch it under the **Actions** tab.
+
+5. **Verify the release.** Once the workflow finishes, the new release appears under [Releases](https://github.com/jhyland87/chem-pal/releases) with two assets:
+   - `chem-pal.crx` — signed, ready to install
+   - `chem-pal-<version>-unpacked.zip` — the unpacked build, for "Load unpacked" in `chrome://extensions`
+
+   The release notes are auto-generated from commits and merged PRs since the previous tag.
+
+## Manual trigger (no tag)
+
+Use the **Actions** tab → **Release** → **Run workflow** button. Enter the version (e.g. `v0.0.13-beta.5`). The workflow will create the tag at the current `HEAD` of the selected branch and publish the release.
+
+Use this for re-running a release without re-tagging locally, or for one-off releases from a non-`main` branch.
+
+## How the version flows into the build
+
+The tag (or dispatch input) becomes:
+
+- **`version_name`** in `public/manifest.json` and **`version`** in `package.json` — the full string with the leading `v` stripped (e.g. `0.0.13-beta.4`). This is what users see in `chrome://extensions`.
+- **`version`** in `public/manifest.json` — the numeric prefix only (e.g. `0.0.13`). Chrome requires this field to be 1–4 dot-separated integers, so prerelease suffixes are dropped.
+
+Edits to `package.json` / `public/manifest.json` happen in the runner's working copy only. Nothing is committed back.
+
+## When something goes wrong
+
+- **Tests fail.** The release job is gated on `test` and `test-e2e`. Fix the failure on `main`, delete the tag, re-tag the new commit:
+
+  ```bash
+  git tag -d v0.0.13-beta.4
+  git push origin :refs/tags/v0.0.13-beta.4
+  # ...fix and commit...
+  git tag v0.0.13-beta.4
+  git push origin v0.0.13-beta.4
+  ```
+
+- **Build or sign step fails.** Same recovery — delete the tag, fix, re-tag. No release is created on failure, so there's nothing to clean up on the Releases page.
+
+- **A bad release was published.** Delete it from the [Releases page](https://github.com/jhyland87/chem-pal/releases), delete the tag (commands above), then cut a new tag.

--- a/wiki_files/Releasing.md
+++ b/wiki_files/Releasing.md
@@ -1,0 +1,66 @@
+# Releasing
+
+Releases are produced by the [`release.yml`](https://github.com/jhyland87/chem-pal/blob/main/.github/workflows/release.yml) workflow. Pushing a `v*` tag (or running the workflow manually) builds the production extension, signs it, and publishes a GitHub Release with the `.crx` and an unpacked-build zip attached.
+
+## Prerequisites
+
+- **`CRX_PRIVATE_KEY` repo secret.** The PEM private key used to sign the `.crx`. Settings → Secrets and variables → Actions → New repository secret. Paste the full PEM, including the `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines and the trailing newline.
+  - The same key must be used for every release — Chrome derives the extension's identity from it. Losing or replacing it produces a different extension ID.
+
+## Cutting a release
+
+1. **Pick a version.** The tag drives everything. Format: `v<major>.<minor>.<patch>` for stable, or `v<major>.<minor>.<patch>-<prerelease>` for betas (e.g. `v0.0.13`, `v0.0.13-beta.4`).
+
+2. **Bump `package.json` to match.** Set `version` to the same string (without the leading `v`). Commit it on `main`. This keeps `main` in sync with what's been released — the workflow will overwrite `package.json` and `public/manifest.json` on the runner regardless, but only for the build artifact.
+
+   ```bash
+   # edit package.json: "version": "0.0.13-beta.4"
+   git commit -am "Bump to 0.0.13-beta.4"
+   git push
+   ```
+
+3. **Tag and push.**
+
+   ```bash
+   git tag v0.0.13-beta.4
+   git push origin v0.0.13-beta.4
+   ```
+
+4. **Watch the run.** The release workflow runs `build → (test + test-e2e in parallel) → release`. The release job only runs if both test suites pass. Watch it under the [Actions](https://github.com/jhyland87/chem-pal/actions) tab.
+
+5. **Verify the release.** Once the workflow finishes, the new release appears under [Releases](https://github.com/jhyland87/chem-pal/releases) with two assets:
+   - `chem-pal.crx` — signed, ready to install
+   - `chem-pal-<version>-unpacked.zip` — the unpacked build, for "Load unpacked" in `chrome://extensions`
+
+   The release notes are auto-generated from commits and merged PRs since the previous tag.
+
+## Manual trigger (no tag)
+
+Use the **Actions** tab → **Release** → **Run workflow** button. Enter the version (e.g. `v0.0.13-beta.5`). The workflow will create the tag at the current `HEAD` of the selected branch and publish the release.
+
+Use this for re-running a release without re-tagging locally, or for one-off releases from a non-`main` branch.
+
+## How the version flows into the build
+
+The tag (or dispatch input) becomes:
+
+- **`version_name`** in `public/manifest.json` and **`version`** in `package.json` — the full string with the leading `v` stripped (e.g. `0.0.13-beta.4`). This is what users see in `chrome://extensions`.
+- **`version`** in `public/manifest.json` — the numeric prefix only (e.g. `0.0.13`). Chrome requires this field to be 1–4 dot-separated integers, so prerelease suffixes are dropped.
+
+Edits to `package.json` / `public/manifest.json` happen in the runner's working copy only. Nothing is committed back.
+
+## When something goes wrong
+
+- **Tests fail.** The release job is gated on `test` and `test-e2e`. Fix the failure on `main`, delete the tag, re-tag the new commit:
+
+  ```bash
+  git tag -d v0.0.13-beta.4
+  git push origin :refs/tags/v0.0.13-beta.4
+  # ...fix and commit...
+  git tag v0.0.13-beta.4
+  git push origin v0.0.13-beta.4
+  ```
+
+- **Build or sign step fails.** Same recovery — delete the tag, fix, re-tag. No release is created on failure, so there's nothing to clean up on the Releases page.
+
+- **A bad release was published.** Delete it from the [Releases page](https://github.com/jhyland87/chem-pal/releases), delete the tag (commands above), then cut a new tag.

--- a/wiki_files/_Sidebar.md
+++ b/wiki_files/_Sidebar.md
@@ -21,3 +21,4 @@
 
 **Development**
 - [Testing](Testing)
+- [Releasing](Releasing)


### PR DESCRIPTION
## Summary
- New \`.github/workflows/release.yml\` triggers on \`v*\` tag push or manual dispatch
- Mirrors main CI: \`build\` → (\`test\` + \`test-e2e\` in parallel) → \`release\`
- Release job derives version from tag, patches \`package.json\` + \`public/manifest.json\` on the runner, signs the \`.crx\` with the \`CRX_PRIVATE_KEY\` repo secret, and publishes a GitHub Release with auto-generated notes
- Attaches both \`chem-pal.crx\` and a zipped unpacked build
- Gitignores \`*.crx\`

## Test plan
- [ ] Merge this PR
- [ ] Confirm \`CRX_PRIVATE_KEY\` repo secret is set
- [ ] Tag main: \`git tag v0.0.13-beta.4 && git push origin v0.0.13-beta.4\`
- [ ] Verify the Release workflow runs and gates release on test + test-e2e
- [ ] Verify the GitHub Release is created with both assets attached
- [ ] (Optional) Test the manual trigger via the Actions tab \"Run workflow\" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)