### PR TITLE
Flag prerelease tags as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,11 @@ jobs:
             EXTRA_ARGS="--target ${{ github.sha }}"
           fi
 
+          # Flag prerelease tags (any with a suffix like -beta.1 / -rc.1) as GitHub pre-releases.
+          case "$TAG" in
+            *-*) EXTRA_ARGS="$EXTRA_ARGS --prerelease" ;;
+          esac
+
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \


### PR DESCRIPTION
The `Release` workflow created every tag as a full GitHub release, so `-beta.N` / `-rc.N` tags (like the just-published `v0.0.14-beta.1`) weren't marked as pre-releases.

This adds `--prerelease` to `gh release create` when the tag contains a `-` suffix:

```sh
case "$TAG" in
  *-*) EXTRA_ARGS="$EXTRA_ARGS --prerelease" ;;
esac
```

Final tags (e.g. `v0.0.14`) are unaffected and still publish as full releases. Takes effect on the next tag pushed after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)