### PR TITLE
Scope Dependabot to github-actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,17 @@
 version: 2
 updates:
-
+  # GitHub Actions only. The npm ecosystem was dropped: its grouped bumps
+  # repeatedly failed CI on the pnpm minimumReleaseAge supply-chain guard
+  # (freshly-published transitive deps) and on lockfile merge conflicts.
+  # Action version bumps have no lockfile and never tripped either, so they
+  # stay automated — grouped into one weekly PR with a release cooldown.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     cooldown:
       default-days: 7
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-    cooldown:
-      semver-minor-days: 7
     groups:
-      dev-dependencies:
-        dependency-type: development
-      production-dependencies:
-        dependency-type: production
-        update-types:
-          - minor
-          - patch
-    ignore:
-      # MUI publishes @mui/material and @mui/icons-material in version lockstep,
-      # and icons-material peer-requires a matching @mui/material major. A solo
-      # major bump breaks the build, so MUI majors are a deliberate, manual
-      # full-stack migration — not a Dependabot PR. Minor/patch still flow.
-      - dependency-name: "@mui/*"
-        update-types:
-          - version-update:semver-major
-    versioning-strategy: increase
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Trims `.github/dependabot.yml` down to the **github-actions** ecosystem and drops **npm**.

## Why
The npm grouped update PRs (#70, #71/#75) repeatedly failed CI on two environmental frictions:
- the pnpm `minimumReleaseAge` supply-chain guard rejecting freshly-published transitive deps (`@babel/*`, `electron-to-chromium`, `tldts`, …) on every lockfile regeneration, and
- lockfile merge conflicts after `main` moved.

Action version bumps have no lockfile and never tripped either check (#66–69 passed cleanly), so they stay automated. npm updates go back to being manual.

## What this keeps
- **github-actions**, `weekly`, all action bumps **grouped into one PR**, with a **7-day cooldown** so brand-new releases settle first.

Supersedes the earlier 'remove entirely' approach on this branch.